### PR TITLE
Modified integration suite test file to fix issue with calling the s3…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,10 @@ COPY . /go/src/github.com/concourse/s3-resource
 WORKDIR /go/src/github.com/concourse/s3-resource
 ENV CGO_ENABLED 0
 RUN go mod download
-RUN go build -o /assets/in ./cmd/in
-RUN go build -o /assets/out ./cmd/out
-RUN go build -o /assets/check ./cmd/check
+RUN go build -o /assets/in github.com/concourse/s3-resource/cmd/in
+RUN go build -o /assets/out github.com/concourse/s3-resource/cmd/out
+RUN go build -o /assets/check github.com/concourse/s3-resource/cmd/check
+WORKDIR /go/src/github.com/concourse/s3-resource
 RUN set -e; for pkg in $(go list ./...); do \
 		go test -o "/tests/$(basename $pkg).test" -c $pkg; \
 	done

--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -2,15 +2,16 @@ package integration_test
 
 import (
 	"encoding/json"
-	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"io/ioutil"
 	"os"
+
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/sts"
-	"github.com/concourse/s3-resource"
+	s3resource "github.com/concourse/s3-resource"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
@@ -126,13 +127,13 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		Ω(endpoint).ShouldNot(BeEmpty(), "must specify $S3_ENDPOINT")
 
 		awsConfig = s3resource.NewAwsConfig(
-		       accessKeyID,
-		       secretAccessKey,
-		       sessionToken,
-		       regionName,
-		       endpoint,
-		       false,
-		       false,
+			accessKeyID,
+			secretAccessKey,
+			sessionToken,
+			regionName,
+			endpoint,
+			false,
+			false,
 		)
 		additionalAwsConfig := aws.Config{}
 		if len(awsRoleARN) != 0 {
@@ -144,7 +145,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 			additionalAwsConfig.Credentials = roleCredentials
 		}
 		s3Service = s3.New(session.New(awsConfig), awsConfig)
-		s3client = s3resource.NewS3Client(ioutil.Discard, awsConfig, v2signing == "true")
+		s3client = s3resource.NewS3Client(ioutil.Discard, awsConfig, v2signing == "true", awsRoleARN)
 	}
 })
 

--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -134,7 +134,15 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		       false,
 		       false,
 		)
+		additionalAwsConfig := aws.Config{}
+		if len(awsRoleARN) != 0 {
+			stsConfig := awsConfig.Copy()
+			stsConfig.Endpoint = nil
+			stsSession := session.Must(session.NewSession(stsConfig))
+			roleCredentials := stscreds.NewCredentials(stsSession, awsRoleARN)
 
+			additionalAwsConfig.Credentials = roleCredentials
+		}
 		s3Service = s3.New(session.New(awsConfig), awsConfig)
 		s3client = s3resource.NewS3Client(ioutil.Discard, awsConfig, v2signing == "true")
 	}


### PR DESCRIPTION
…resource

## Changes proposed in this pull request:

- Added fix to integration testing suite for testing `AwsRoleARN`
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

There are no security considerations for the change.