### PR TITLE
envar needs to be in each image block

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN apt update \
   zip \
   && rm -rf /var/lib/apt/lists/*
 COPY --from=builder assets/ /opt/resource/
+ENV AWS_USE_FIPS_ENDPOINT true
 RUN chmod +x /opt/resource/*
 
 FROM resource AS tests
@@ -38,6 +39,7 @@ ARG S3_TESTING_BUCKET
 ARG S3_TESTING_REGION
 ARG S3_ENDPOINT
 ARG TEST_SESSION_TOKEN
+ENV AWS_USE_FIPS_ENDPOINT true
 COPY --from=builder /tests /go-tests
 WORKDIR /go-tests
 RUN set -e; for test in /go-tests/*.test; do \
@@ -45,3 +47,4 @@ RUN set -e; for test in /go-tests/*.test; do \
   done
 
 FROM resource
+ENV AWS_USE_FIPS_ENDPOINT true


### PR DESCRIPTION
## Changes proposed in this pull request:

The fips endpoint envar needs to be in each image block. Actually, it needs to be in the test and final images, but this gives us the best coverage.

## Security considerations

Required for compliance
