### PR TITLE
virtual style access is required for fips endpoints

### DIFF
--- a/s3client.go
+++ b/s3client.go
@@ -154,7 +154,7 @@ func NewAwsConfig(
 	awsConfig := &aws.Config{
 		Region:           aws.String(regionName),
 		Credentials:      creds,
-		S3ForcePathStyle: aws.Bool(true),
+		S3ForcePathStyle: aws.Bool(false),
 		MaxRetries:       aws.Int(maxRetries),
 		DisableSSL:       aws.Bool(disableSSL),
 		HTTPClient:       httpClient,


### PR DESCRIPTION
## Changes proposed in this pull request:

- Disables the use of path style access. FIPS endpoints in commercial require virtual style access: https://github.com/aws/aws-sdk-go/blob/7112c0a0c2d01713a9db2d57f0e5722225baf5b5/service/s3/s3manager/bucket_region.go#L44

## Security considerations

None. Fips endpoints are required for compliance. 
